### PR TITLE
Add stylesheet to expand WeChat to fill browser window.

### DIFF
--- a/service.css
+++ b/service.css
@@ -1,0 +1,9 @@
+.main {
+  padding-top: 0;
+  height: 100vh;
+}
+
+.main_inner {
+  margin: 0;
+  max-width: 100%;
+}

--- a/webview.js
+++ b/webview.js
@@ -1,4 +1,5 @@
 'use strict';
+const path = require('path');
 
 module.exports = (Franz, options) => {
   function getMessages() {
@@ -24,6 +25,8 @@ module.exports = (Franz, options) => {
 
     Franz.setBadge(directCount, indirectCount);
   }
+
+  Franz.injectCSS(path.join(__dirname, 'service.css'));
 
   Franz.loop(getMessages);
 }


### PR DESCRIPTION
Brings this service more in-line with what users would expect. 

I've been using this particular stylesheet in Chrome for ages. Works great.

Screenshot:
![image](https://user-images.githubusercontent.com/5861371/32479840-4faea612-c351-11e7-95ab-729253db4e50.png)
